### PR TITLE
[issue-14] Попытка исправить \Bitrix\Main\Entity\ExpressionField

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -150,17 +150,17 @@ class Manager
 	 *
 	 * @return array
 	 */
-	protected static function prepareOnValues($params)
+	protected static function prepareOnKeys($params)
 	{
+		$params = array_unique($params);
+
 		$arProps = [];
 
 		foreach ($params as $value){
-			if (is_string($value) && preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)) {
+			if(preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)){
 				$arProps[] = $parseProp[1];
 			}
 		}
-
-		$arProps = array_unique($arProps);
 
 		return $arProps;
 	}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -150,17 +150,17 @@ class Manager
 	 *
 	 * @return array
 	 */
-	protected static function prepareOnKeys($params)
+	protected static function prepareOnValues($params)
 	{
-		$params = array_unique($params);
-
 		$arProps = [];
 
 		foreach ($params as $value){
-			if(preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)){
+			if (is_string($value) && preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)) {
 				$arProps[] = $parseProp[1];
 			}
 		}
+
+		$arProps = array_unique($arProps);
 
 		return $arProps;
 	}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -173,14 +173,15 @@ class Manager
 	 */
 	protected static function prepareOnValues($params)
 	{
-		$params = array_unique($params);
 		$arProps = [];
 
 		foreach ($params as $value){
-			if(preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)){
+			if (is_string($value) && preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)) {
 				$arProps[] = $parseProp[1];
 			}
 		}
+
+		$arProps = array_unique($arProps);
 
 		return $arProps;
 	}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -152,15 +152,16 @@ class Manager
 	 */
 	protected static function prepareOnKeys($params)
 	{
-		$params = array_unique($params);
 
 		$arProps = [];
 
 		foreach ($params as $value){
-			if(preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)){
+			if(is_string($value) && preg_match('#^PROPERTY.(.*)#i', $value, $parseProp)){
 				$arProps[] = $parseProp[1];
 			}
 		}
+		
+		$arProps = array_unique($arProps);
 
 		return $arProps;
 	}


### PR DESCRIPTION
Думаю не производя array_unique в Manager на prepateOn функциях можно получить необходимый эффект. 
Пусть будет чуть более длинный перебор, но точно не вызовет проблемы с попыткой приведения ExpressionField в string